### PR TITLE
globalize require

### DIFF
--- a/menu.lua
+++ b/menu.lua
@@ -8,6 +8,8 @@ if not term.isColour or not term.isColour() then
 	error( "Zombease requires an advanced computer!", 0 )
 end
 
+_G.require = require
+
 if not fs.exists "blittle" then shell.run "pastebin get ujchRSnU blittle" end
 os.loadAPI "blittle"
 local blittle = blittle


### PR DESCRIPTION
Just thought I'd try this game out, 2 years after release. Didn't work first try but it was a one line fix, which is a relief considering how much CC has changed. I really don't understand how `require` wasn't in the global table, but in the local `menu.lua` one, it's quite peculiar. In either case I fixed it so that someone like myself playing in a version of CC that's not from 2 years ago can enjoy :)